### PR TITLE
Nueva regla del linter para evitar type any

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
   ],
   "rules": {
     "no-console": 2,
-    "prefer-const": 2
+    "prefer-const": 2,
+    "@typescript-eslint/no-explicit-any": 2
   }
 }


### PR DESCRIPTION
Nueva regla del linter para evitar type any


