### PR TITLE
87 agregar endpoints para postulaciones talks

### DIFF
--- a/pages/api/talks/[id].ts
+++ b/pages/api/talks/[id].ts
@@ -1,11 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import errorHandler, { err } from "../../../lib/error-handling";
-import { updateStatusFromTalks } from "../../../services/talks";
+import { getTalk, updateStatusFromTalks } from "../../../services/talks";
 
 export default errorHandler(
   async (req: NextApiRequest, res: NextApiResponse) => {
     const { body, method } = req;
     const { id = "" }: { id?: string } = req.query;
+
+    if (method === "GET") {
+      const data = await getTalk(id);
+      const message = undefined;
+
+      return res.status(200).json({ data, message });
+    }
 
     if (method === "PUT") {
       const data = await updateStatusFromTalks(id, body);

--- a/pages/api/talks/[id].ts
+++ b/pages/api/talks/[id].ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import errorHandler, { err } from "../../../lib/error-handling";
+import { updateStatusFromTalks } from "../../../services/talks";
+
+export default errorHandler(
+  async (req: NextApiRequest, res: NextApiResponse) => {
+    const { body, method } = req;
+    const { id = "" }: { id?: string } = req.query;
+
+    if (method === "PUT") {
+      const data = await updateStatusFromTalks(id, body);
+      const message = "Se ha actualizado la propuesta";
+
+      return res.status(200).json({ data, message });
+    }
+
+    res.status(405).json(err[405]);
+  }
+);

--- a/pages/api/talks/index.ts
+++ b/pages/api/talks/index.ts
@@ -1,0 +1,18 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import errorHandler, { err } from "../../../lib/error-handling";
+import { postTalk } from "../../../services/talks";
+
+export default errorHandler(
+  async (req: NextApiRequest, res: NextApiResponse) => {
+    const { body, method } = req;
+
+    if (method === "POST") {
+      const data = await postTalk(body);
+      const message = "Se ha creado la propuesta";
+
+      return res.status(201).json({ data, message });
+    }
+
+    res.status(405).json(err[405]);
+  }
+);

--- a/pages/api/talks/index.ts
+++ b/pages/api/talks/index.ts
@@ -1,10 +1,18 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import errorHandler, { err } from "../../../lib/error-handling";
-import { postTalk } from "../../../services/talks";
+import { getTalksFromEvent, postTalk } from "../../../services/talks";
 
 export default errorHandler(
   async (req: NextApiRequest, res: NextApiResponse) => {
-    const { body, method } = req;
+    const { body, method, query } = req;
+    const { "event-id": eventId } = req.query;
+
+    if (method === "GET") {
+      const data = await getTalksFromEvent(eventId as string, query);
+      const message = undefined;
+
+      return res.status(200).json({ data, message });
+    }
 
     if (method === "POST") {
       const data = await postTalk(body);

--- a/services/candidate.ts
+++ b/services/candidate.ts
@@ -3,6 +3,7 @@ import { db } from "../lib/firebase-config";
 import { Candidate } from "../types/candidates-types";
 
 export async function saveCandidate(dataCandidate: Candidate) {
+  dataCandidate.id = dataCandidate.email;
   const docRef = await setDoc(
     doc(db, "candidates", dataCandidate.email),
     dataCandidate

--- a/services/talks.ts
+++ b/services/talks.ts
@@ -129,7 +129,7 @@ export const postTalk = async ({
   return { ...talkData, topics: topicsData, candidates: candidatesData };
 };
 
-export const getTalk = async (talkId: string) => {
+export const getTalk = async (talkId: TalkProposalId) => {
   if (!talkId) {
     throw { code: 422, message: "Se requiere el ID de la propuesta de charla" };
   }

--- a/services/talks.ts
+++ b/services/talks.ts
@@ -15,6 +15,7 @@ import { Candidate, CandidateId } from "../types/candidates-types";
 import {
   ProposalStatus,
   TalkProposal,
+  TalkProposalId,
   Topic,
   TopicId,
 } from "../types/talk-types";
@@ -43,12 +44,16 @@ export const getTalksFromEvent = async (eventId: string) => {
 };
 
 export const updateStatusFromTalks = async (
-  params: Pick<TalkProposal, "id" | "status">
+  talkId: TalkProposalId,
+  { status }: Pick<TalkProposal, "status">
 ) => {
   // update status from talks
-  const TalksRef = doc(db, "talks", params.id);
-  await updateDoc(TalksRef, {
-    status: params.status,
+  if (!status) {
+    throw { code: 422, message: "Se requiere el estado de la propuesta" };
+  }
+  const TalksRef = doc(db, "talks", talkId);
+  await updateDoc(TalksRef, { status }).catch(() => {
+    throw { code: 404, message: `El evento no existe!` };
   });
 };
 

--- a/types/others.ts
+++ b/types/others.ts
@@ -20,3 +20,11 @@ export interface QueryParams {
   order?: OrderByDirection;
   type?: string | string[];
 }
+
+export interface FilterOptions {
+  duration?: string;
+  order?: OrderByDirection;
+  status?: string;
+  streamed?: string;
+  topics?: string[];
+}


### PR DESCRIPTION
<!--- link del issue -->

Issue #87, tambien soluciona los issues #44 y #83

<!--- descripción -->

Se agregaron los endpoints para las postulaciones y tambien la posibilidad de filtar y ordernar las postulaciones de un evento.

**Notes:**
- Se va a requerir agregar `eventId`  y `createdAt` (para ordenar por fecha de postulacion) a los types y mocks de postulaciones (talks), se le pueden cambiar los nombres, no problem.
- Se asume que filtrar por Formato era igual a `streamed`.

<!--- videos/imagenes -->



