### PR TITLE
96 agregar endpoint para el agregado de un nuevo tema topic

### DIFF
--- a/pages/api/topics/index.ts
+++ b/pages/api/topics/index.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import errorHandler, { err } from "../../../lib/error-handling";
+import { addTopic } from "../../../services/topic";
+
+export default errorHandler(
+  async (req: NextApiRequest, res: NextApiResponse) => {
+    const { body, method } = req;
+
+    if (method === "POST") {
+      const data = await addTopic(body);
+
+      const message: string = "Se ha creado el tópico";
+
+      return res.status(201).json({ data, message });
+    }
+
+    res.status(405).json(err[405]);
+  }
+);

--- a/services/topic.ts
+++ b/services/topic.ts
@@ -17,6 +17,7 @@ export const addTopic = (topics: Pick<Topic, "description">[]) => {
 
     const [topicData] = topicsSnap.docs.map((topic) => {
       const data = topic.data();
+      data.id = topic.id;
       return data;
     });
 

--- a/services/topic.ts
+++ b/services/topic.ts
@@ -3,7 +3,27 @@ import { collectionsRef } from "../lib/firebase-config";
 import { Topic } from "../types/talk-types";
 
 export const addTopic = (topics: Pick<Topic, "description">[]) => {
+  // Topic needs to be an array.
+  if (!Array.isArray(topics)) {
+    throw { code: 422, message: `Topics needs to be an array.` };
+  }
+
+  // Check if topic arr isn't empty
+  if (topics.length <= 0) {
+    throw { code: 422, message: "Es requerido al menos un tópico." };
+  }
+
   const topicsId = topics.map(async ({ description }) => {
+    // Check if there is a description.
+    if (!description) {
+      throw { code: 422, message: "There is no description" };
+    }
+
+    // Check if description isn't an empty string.
+    if (!description.trim()) {
+      throw { code: 422, message: "An empty string isn't valid." };
+    }
+
     const constrain = where("description", "==", description);
     const q = query(collectionsRef.topics, constrain);
 


### PR DESCRIPTION
### Resolve:
[Agregar endpoint para el agregado de un nuevo Tema (Topic) #96](https://github.com/frontendcafe/water-call-for-papers/issues/96)

### Description

Se crea endpoint para agregar nuevos topicos con el metodo HTTP `POST` 
Ademas se agregan validaciones con mensajes correspondientes para validar informacion recibida.


