### PR TITLE
160-issue-no-se-muestran-colores-de-los-eventos-en-el-sidebar

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -74,3 +74,12 @@ export const isStatus = (params: EventStatus): boolean => {
 export const isType = (params: EventType): boolean => {
   return Object.values(EventType).includes(params);
 };
+
+/**
+ * Generates an integer between @min and @max, both are included.
+ * @param min Number, minimum
+ * @param max Number, maximum
+ * @returns Random integer
+ */
+export const randomIntegerBetween = (min: number, max: number): number =>
+  Math.floor(Math.random() * (max - min + 1) + min);

--- a/pages/event/create.tsx
+++ b/pages/event/create.tsx
@@ -49,6 +49,7 @@ const Create = () => {
     Themes: "",
     Description: "",
     Requirements: "",
+    Location: "",
   });
 
   const [selected, setSelected] = useState<SelectedOption>(modalityOptions[0]);
@@ -114,7 +115,6 @@ const Create = () => {
     const isEmptyValue = inputsValues.some(
       (value) => value === undefined || value === null
     );
-
     checkInputValue(startDate, setIsNotStarDateValue);
     checkInputValue(endDate, setIsNotEndDateValue);
     checkInputValue(timeZoneSelected, setIsNotTimeZoneValue);
@@ -160,7 +160,6 @@ const Create = () => {
   ) => {
     const regex = new RegExp(/^[A-ZÑa-zñáéíóúÁÉÍÓÚ0-9\s]+$/g);
     const validation = regex.test(e.target.value);
-
     if (
       [
         "OrganizationName",
@@ -342,13 +341,14 @@ const Create = () => {
                 defaultValue={modalityOptions[0].value}
               ></RadioButtons>
             </div>
-            <div>
+            <div className="pb-6">
               <InputText
                 label="Localización"
                 placeholder="Ingrese localización"
                 idValue="Location"
-                value={data["Location"]}
+                value={data.Location}
                 onChange={handleValidation}
+                error={dataError.Location}
               />
             </div>
           </AccordionDefault>

--- a/stories/SidebarDrawer/SidebarDrawer.tsx
+++ b/stories/SidebarDrawer/SidebarDrawer.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import logo_vercel from "../../public/img/vercel-logo-white.svg";
 import { EventData } from "../../types/events-types";
 import { Button } from "../Button/Button";
@@ -22,7 +22,15 @@ interface DrawerCompProps {
   events: EventData[];
   ariaLabel: string;
   isOpen: boolean;
+  colors?: Array<string>;
 }
+
+const colors = [
+  ["text-[#B81B31]", "bg-[#FFE5EF]"],
+  ["text-[#124C47]", "bg-[#E7FFFE]"],
+  ["text-[#6D4F19]", "bg-[#FFFAE3]"],
+  ["text-[#245938]", "bg-[#D1FADF]"],
+];
 
 const isMobile = () => window.matchMedia("(max-width: 768px)").matches;
 
@@ -30,16 +38,26 @@ const iconStyles = "inline-flex flex-shrink-0";
 
 export const SidebarDrawer = ({ events = [] }: SidebarProps) => {
   const { sidebarState, setSidebarState } = useSidebarReducer();
+  const [eventColors, setEventColors] = useState<Array<string>>([]);
   const { ariaExpanded, isOpen } = sidebarState;
 
   useEffect(() => {
     const type = isMobile() ? Action.MOBILE_INITIAL : Action.DESKTOP_INITIAL;
     setSidebarState({ type });
+    setEventColors(generateEventColors);
   }, []);
 
   const clickHandler = () => {
     const type = isMobile() ? Action.MOBILE : Action.DESKTOP;
     setSidebarState({ type });
+  };
+
+  const generateEventColors = () => {
+    const generatedColors: Array<string> = [];
+    events.forEach(() => {
+      generatedColors.push(colors[randomIntegerBetween(0, 3)].join(" "));
+    });
+    return generatedColors;
   };
 
   const responsiveBehavior = `md:translate-x-0 w-full ${
@@ -65,7 +83,11 @@ export const SidebarDrawer = ({ events = [] }: SidebarProps) => {
             <Icon className={iconStyles} iconName="plusCircle" />
           </StyledLink>
 
-          <EventsNavSection {...sidebarState} events={events} />
+          <EventsNavSection
+            colors={eventColors}
+            {...sidebarState}
+            events={events}
+          />
         </div>
 
         <AboutNavSection {...sidebarState} />
@@ -152,14 +174,8 @@ function BrandSection({
 function EventsNavSection({
   events,
   isOpen,
+  colors,
 }: Omit<DrawerCompProps, "clickHandler">) {
-  const colors = [
-    ["text-[#B81B31]", "bg-[#FFE5EF]"],
-    ["text-[#124C47]", "bg-[#E7FFFE]"],
-    ["text-[#6D4F19]", "bg-[#FFFAE3]"],
-    ["text-[#245938]", "bg-[#D1FADF]"],
-  ];
-
   return (
     <div className="space-y-2">
       <h2>
@@ -170,24 +186,23 @@ function EventsNavSection({
       </h2>
 
       <ul aria-label="Listado de próximos eventos" className="space-y-2">
-        {events.map(({ id, name }) => {
-          const textColors = colors[randomIntegerBetween(0, 3)].join(" ");
-          return (
-            <li key={id}>
-              <StyledLink href={`/event/${id}`}>
-                <div
-                  className={`inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-xs rounded-full ${textColors}`}
-                >
-                  {name.substring(0, 2).toUpperCase()}
-                </div>
+        {events.map(({ id, name }, index) => (
+          <li key={id}>
+            <StyledLink href={`/event/${id}`}>
+              <div
+                className={`inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-xs rounded-full ${
+                  colors ? colors[index] : ""
+                }`}
+              >
+                {name.substring(0, 2).toUpperCase()}
+              </div>
 
-                <TextContainer truncate isOpen={isOpen}>
-                  {name}
-                </TextContainer>
-              </StyledLink>
-            </li>
-          );
-        })}
+              <TextContainer truncate isOpen={isOpen}>
+                {name}
+              </TextContainer>
+            </StyledLink>
+          </li>
+        ))}
       </ul>
     </div>
   );

--- a/stories/SidebarDrawer/SidebarDrawer.tsx
+++ b/stories/SidebarDrawer/SidebarDrawer.tsx
@@ -45,7 +45,7 @@ export const SidebarDrawer = ({ events = [] }: SidebarProps) => {
     const type = isMobile() ? Action.MOBILE_INITIAL : Action.DESKTOP_INITIAL;
     setSidebarState({ type });
     setEventColors(generateEventColors);
-  }, []);
+  }, [events]);
 
   const clickHandler = () => {
     const type = isMobile() ? Action.MOBILE : Action.DESKTOP;

--- a/stories/SidebarDrawer/SidebarDrawer.tsx
+++ b/stories/SidebarDrawer/SidebarDrawer.tsx
@@ -8,6 +8,7 @@ import { LogoCallForPapers } from "../Spinner/LogoCallForPapers";
 import { StyledLink } from "..//StyledLink/StyledLink";
 import { TextContainer } from "./TextContainer";
 import { Action, useSidebarReducer } from "./useSidebarReducer";
+import { randomIntegerBetween } from "../../lib/utils";
 
 interface SidebarProps {
   /**
@@ -152,6 +153,13 @@ function EventsNavSection({
   events,
   isOpen,
 }: Omit<DrawerCompProps, "clickHandler">) {
+  const colors = [
+    ["text-[#B81B31]", "bg-[#FFE5EF]"],
+    ["text-[#124C47]", "bg-[#E7FFFE]"],
+    ["text-[#6D4F19]", "bg-[#FFFAE3]"],
+    ["text-[#245938]", "bg-[#D1FADF]"],
+  ];
+
   return (
     <div className="space-y-2">
       <h2>
@@ -162,19 +170,24 @@ function EventsNavSection({
       </h2>
 
       <ul aria-label="Listado de próximos eventos" className="space-y-2">
-        {events.map(({ id, name }) => (
-          <li key={id}>
-            <StyledLink href={`/event/${id}`}>
-              <div className="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-xs text-black rounded-full bg-secondary-100">
-                {name.substring(0, 2).toUpperCase()}
-              </div>
+        {events.map(({ id, name }) => {
+          const textColors = colors[randomIntegerBetween(0, 3)].join(" ");
+          return (
+            <li key={id}>
+              <StyledLink href={`/event/${id}`}>
+                <div
+                  className={`inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-xs rounded-full ${textColors}`}
+                >
+                  {name.substring(0, 2).toUpperCase()}
+                </div>
 
-              <TextContainer truncate isOpen={isOpen}>
-                {name}
-              </TextContainer>
-            </StyledLink>
-          </li>
-        ))}
+                <TextContainer truncate isOpen={isOpen}>
+                  {name}
+                </TextContainer>
+              </StyledLink>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );


### PR DESCRIPTION
<!--- link del issue -->

Resuelve: [Issue: No se muestran colores de los eventos en el sidebar #160](https://github.com/frontendcafe/water-call-for-papers/issues/160)

<!--- descripción -->
**Descripcion:**

De un array con colores disponibles para los 'iconos' se selecciona uno de manera aleatoria, luego el color de texto y back ground es aplicado al elemento correspondiente.

**Imagenes**

![Screenshot_2022-11-05-09-02-03_3280x1080](https://user-images.githubusercontent.com/96669064/200147783-ee01c6c8-23c1-4355-b47a-332b85a036d7.png)

![Screenshot_2022-11-05-09-00-00_3280x1080](https://user-images.githubusercontent.com/96669064/200147796-a5b6e841-fef1-4819-90a4-e2209ce78eeb.png)
